### PR TITLE
Fix typos on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,20 @@ output: github_document
 
 
 This repository contains course notes, data, and slides for the R for Data Science
-course taught with CoRise. 
+course taught by CoRise. 
 
 ## Getting Started
 
 ### Install the `gitpod` extension
 
-The easiest way to get started is by installing the [gitpod browser extension](https://www.gitpod.io/docs/configure/user-settings/browser-extension). Once you add this extension, you will see a green colored gitpod button in every github repository that has integrated with gitpod.
+The easiest way to get started is by installing the [gitpod browser extension](https://www.gitpod.io/docs/configure/user-settings/browser-extension). Once you add this extension, you will see a green colored gitpod button in every GitHub repository that has integrated with gitpod.
 
 ![gitpod-button](https://imgur.com/2RYt1RN.png)
 
 
-### Fork this repository to your github account
+### Fork this repository to your GitHub account
 
-The next step is to fork this repository to your github account. Doing this will let you work with your own copy of the data and documents and allow you to make and save changes.
+The next step is to fork this repository to your GitHub account. Doing this will let you work with your own copy of the data and documents and allow you to make and save changes.
 
 ![fork-repo](https://imgur.com/woqAXx9.png)
 
@@ -27,11 +27,11 @@ The next step is to fork this repository to your github account. Doing this will
 
 This will take you to `gitpod`. You might be prompted to sign in to `gitpod` if you have not already done so. I would recommend using the `github` sign in as it would make it a lot easier for you to save your changes back to `github`.
 
-The first time you open a github repository in `gitpod`, it will prompt you to start a new workspace. You can accept the defaults as-is and click on the continue button.
+The first time you open a GitHub repository in `gitpod`, it will prompt you to start a new workspace. You can accept the defaults as-is and click on the continue button.
 
 ![gitpod-settings](https://i.imgur.com/GlL1r7U.png)
 
-Gitpod will create a workspace for your github repository and open it in your browser. If all goes, you will be greeted with this screen.
+Gitpod will create a workspace for your GitHub repository and open it in your browser. If all goes well, you will be greeted with this screen.
 
 ![gitpod-vscode](https://i.imgur.com/guWJPVJ.png)
 


### PR DESCRIPTION
I fixed some tiny typos (e.g., from github to GitHub and "course taught with CoRise to "course taught by CoRise"). Otherwise, it looks good to go!