### PR TITLE
Add janitor and zoo libraries to DESCRIPTION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,10 +12,12 @@ Imports:
     here,
     hexbin,
     Hmisc,
+    janitor,
     leaflet,
     markdown,
     plotly,
     shiny,
     statebins,
     xaringanExtra,
-    xaringanthemer
+    xaringanthemer,
+    zoo


### PR DESCRIPTION
These are missing when I load the environment
This caused errors when running the `tbl-lifetables-extended` (`zoo`) and `tbl-names-extended-age` (`janitor`) chunks.